### PR TITLE
explicitly install poetry-plugin-export

### DIFF
--- a/Dockerfile.buildbase
+++ b/Dockerfile.buildbase
@@ -7,7 +7,9 @@ RUN dnf -y install gcc-c++ python3.12-devel openssl-devel \
 COPY constraints.txt constraints.txt
 
 # Setup poetry
-RUN python3 -m pip install --constraint constraints.txt poetry==1.8.3 \
+RUN python3 -m pip install --constraint constraints.txt \
+    poetry==1.8.3 \
+    poetry-plugin-export==1.8.0 \
  && python3 -m poetry config virtualenvs.create false
 
 # Setup coverage


### PR DESCRIPTION
## Changes introduced with this PR

Responding to warning from poetry:
```
Warning: poetry-plugin-export will not be installed by default in a future version of Poetry.
In order to avoid a breaking change and make your automation forward-compatible, please install poetry-plugin-export explicitly. See https://python-poetry.org/docs/plugins/#using-plugins for details on how to install a plugin.
```
---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).