### PR TITLE
Use ARCALOT_POETRY_VERSION org variable

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,6 +72,8 @@ jobs:
           context: .
           file: Dockerfile.buildbase
           platforms: linux/amd64, linux/arm64
-          build-args: image_tag=${{ env.IMAGE_TAG }}
+          build-args: |
+            image_tag=${{ env.IMAGE_TAG }}
+            poetry_version=${{ vars.ARCALOT_POETRY_VERSION }}
           push: ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' }}
           tags: quay.io/${{ secrets.QUAY_NAMESPACE }}/arcaflow-plugin-baseimage-python-buildbase:${{ env.IMAGE_TAG }}

--- a/Dockerfile.buildbase
+++ b/Dockerfile.buildbase
@@ -1,13 +1,15 @@
 ARG image_tag
 
 FROM quay.io/arcalot/arcaflow-plugin-baseimage-python-osbase:$image_tag
+ARG poetry_version
 RUN dnf -y install gcc-c++ python3.12-devel openssl-devel \
  && dnf clean all
 
 COPY constraints.txt constraints.txt
 
 # Setup poetry
-RUN python3 -m pip install --constraint constraints.txt poetry==1.8.3 \
+RUN python3 -m pip install --constraint constraints.txt \
+    poetry==${poetry_version} \
  && python3 -m poetry config virtualenvs.create false
 
 # Setup coverage


### PR DESCRIPTION
## Summary
- Replace hardcoded `poetry==1.8.3` in `Dockerfile.buildbase` with a Docker build arg sourced from the `ARCALOT_POETRY_VERSION` org-level GitHub variable.
- Pass the variable through the CI workflow's `build-args` to the Docker build.
- This centralizes Poetry version management across all Arcaflow repos alongside the existing `ARCALOT_PYTHON_SUPPORTED_VERSIONS` and `ARCALOT_PYTHON_VERSION` variables.

## Test plan
- [ ] Set new org variable `ARCALOT_POETRY_VERSION` to `1.8.3`
- [ ] Verify the base image builds successfully with the variable

🤖 Generated with [Claude Code](https://claude.com/claude-code)